### PR TITLE
Fix: enforce admin auth for management interfaces and add SSRF redirect validation

### DIFF
--- a/configs/gemini.yaml
+++ b/configs/gemini.yaml
@@ -12,7 +12,7 @@ server:
   cors:
     # Allow all origins with "*", but specify exact origins when allow_credentials is true for security
     allow_origins: ["*"]
-    allow_credentials: true
+    allow_credentials: false
     allow_methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
     allow_headers: ["*"]
 

--- a/configs/novelai.yaml
+++ b/configs/novelai.yaml
@@ -12,7 +12,7 @@ server:
   cors:
     # Allow all origins with "*", but specify exact origins when allow_credentials is true for security
     allow_origins: ["*"]
-    allow_credentials: true
+    allow_credentials: false
     allow_methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
     allow_headers: ["*"]
 

--- a/configs/openai.yaml
+++ b/configs/openai.yaml
@@ -1,5 +1,6 @@
 server:
-  api_key: 
+  # IMPORTANT: Set an API key to secure all endpoints. Leave empty to auto-generate an admin key.
+  api_key:
   logging:
     enabled: true
     level: debug
@@ -12,7 +13,7 @@ server:
   cors:
     # Allow all origins with "*", but specify exact origins when allow_credentials is true for security
     allow_origins: ["*"]
-    allow_credentials: true
+    allow_credentials: false
     allow_methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
     allow_headers: ["*"]
 

--- a/nya/config.yaml
+++ b/nya/config.yaml
@@ -2,7 +2,10 @@
 # This file contains server settings and API endpoint configurations
 
 server:
-  api_key: 
+  # IMPORTANT: Set an API key to secure all proxy and management endpoints.
+  # If left empty, a random admin key is auto-generated on startup for /config and /dashboard only.
+  # Proxy routes will remain open without authentication until an API key is configured.
+  api_key:
   logging:
     enabled: true
     level: debug
@@ -13,9 +16,10 @@ server:
   dashboard:
     enabled: true
   cors:
-    # Allow all origins with "*", but specify exact origins when allow_credentials is true for security
+    # Specify exact origins when allow_credentials is true for security.
+    # Using "*" with allow_credentials: true is forbidden by the CORS specification.
     allow_origins: ["*"]
-    allow_credentials: true
+    allow_credentials: false
     allow_methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
     allow_headers: ["*"]
 

--- a/nya/core/request.py
+++ b/nya/core/request.py
@@ -2,8 +2,10 @@
 Simplified request executor focused on HTTP execution only.
 """
 
+import ipaddress
 import time
 from typing import TYPE_CHECKING, Optional, Union
+from urllib.parse import urlparse
 
 import httpx
 from loguru import logger
@@ -16,6 +18,40 @@ if TYPE_CHECKING:
     from ..common.models import ProxyRequest
     from ..config.manager import ConfigManager
     from ..services.metrics import MetricsCollector
+
+
+# Private/local IP ranges that redirects should not follow
+_PRIVATE_NETWORKS = [
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+]
+
+
+def _is_private_url(url: str) -> bool:
+    """Check if a URL points to a private/internal IP address."""
+    try:
+        hostname = urlparse(url).hostname
+        if not hostname:
+            return False
+        addr = ipaddress.ip_address(hostname)
+        return any(addr in net for net in _PRIVATE_NETWORKS)
+    except (ValueError, TypeError):
+        return False
+
+
+def _validate_redirect(request: httpx.Request, response: httpx.Response) -> None:
+    """Validate redirect target is not a private IP (SSRF protection)."""
+    target = response.headers.get("location", "")
+    if target and _is_private_url(target):
+        raise httpx.TooManyRedirects(
+            f"Redirect to private IP address blocked: {target}"
+        )
 
 
 class RequestExecutor:
@@ -47,12 +83,16 @@ class RequestExecutor:
 
         client_kwargs = {
             "follow_redirects": True,
+            "max_redirects": 5,
             "timeout": timeout,
             "limits": httpx.Limits(
                 max_connections=2000,
                 max_keepalive_connections=500,
                 keepalive_expiry=min(120.0, proxy_timeout),
             ),
+            "event_hooks": {
+                "response": [_validate_redirect],
+            },
         }
 
         # Add proxy support if configured

--- a/nya/server/auth.py
+++ b/nya/server/auth.py
@@ -4,9 +4,11 @@ Provides authentication mechanisms and middleware.
 """
 
 import importlib.resources
-from typing import TYPE_CHECKING
+import secrets
+from typing import TYPE_CHECKING, Optional
 
 from fastapi import Request
+from loguru import logger
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import HTMLResponse, JSONResponse
 
@@ -27,12 +29,39 @@ class AuthManager:
             config: The configuration manager instance
         """
         self.config = config
+        self._auto_generated_key: Optional[str] = None
 
     def get_api_key(self):
         """
         Get the configured API key
         """
         return self.config.get_api_key()
+
+    def ensure_admin_key(self) -> str:
+        """
+        Ensure an admin key exists for management interfaces.
+        Auto-generates one if no API key is configured.
+        """
+        configured_key = self.get_api_key()
+        if configured_key and not (
+            isinstance(configured_key, str) and not configured_key.strip()
+        ):
+            if isinstance(configured_key, list):
+                return configured_key[0].strip()
+            return configured_key.strip()
+
+        if self._auto_generated_key is None:
+            self._auto_generated_key = secrets.token_urlsafe(32)
+            logger.warning(
+                "=" * 60 + "\n"
+                "SECURITY NOTICE: No API key configured.\n"
+                "A random admin key has been generated for /config and /dashboard:\n"
+                f"  {self._auto_generated_key}\n"
+                "Use this key in the Authorization header to access management interfaces.\n"
+                "Set 'server.api_key' in your config file for persistent configuration.\n"
+                + "=" * 60
+            )
+        return self._auto_generated_key
 
     def verify_api_key(self, key: str, verify_master: bool = False) -> bool:
         """
@@ -152,12 +181,35 @@ class AuthMiddleware(BaseHTTPMiddleware):
         if any(request.url.path == path for path in excluded_paths):
             return await call_next(request)
 
-        configured_key = self.auth.get_api_key()
+        is_dashboard = request.url.path.startswith("/dashboard")
+        is_config = request.url.path.startswith("/config")
 
-        # No API key required if configured_key is None or empty string/list
-        if configured_key is None or (
+        configured_key = self.auth.get_api_key()
+        key_is_unset = configured_key is None or (
             isinstance(configured_key, (str, list)) and not configured_key
-        ):
+        )
+
+        # Management interfaces (/config, /dashboard) ALWAYS require auth
+        if is_dashboard or is_config:
+            if key_is_unset:
+                admin_key = self.auth.ensure_admin_key()
+                provided = ""
+                auth_header = request.headers.get("Authorization", "")
+                if auth_header.startswith("Bearer "):
+                    provided = auth_header[7:]
+                cookie_key = request.cookies.get("nyaproxy_api_key", "")
+                if secrets.compare_digest(admin_key, provided) or \
+                   secrets.compare_digest(admin_key, cookie_key.strip()):
+                    return await call_next(request)
+            else:
+                if self.auth.verify_session_cookie(request):
+                    return await call_next(request)
+                if self.auth.verify_api_key_header(request):
+                    return await call_next(request)
+            return self._generate_login_page(request)
+
+        # For proxy routes: no auth needed if API key is not set
+        if key_is_unset:
             return await call_next(request)
 
         # First, check for valid session cookie
@@ -167,14 +219,6 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # Then, check for valid Authorization header
         if self.auth.verify_api_key_header(request):
             return await call_next(request)
-
-        # If no valid auth found, determine response based on path
-        is_dashboard = request.url.path.startswith("/dashboard")
-        is_config = request.url.path.startswith("/config")
-
-        # For dashboard and config paths, redirect to login page
-        if is_dashboard or is_config:
-            return self._generate_login_page(request)
 
         # For API and other paths, return JSON error
         return JSONResponse(


### PR DESCRIPTION
## Summary

The default empty `api_key` in the configuration file leaves `/config` (NekoConfOrchestrator web UI) and `/dashboard` accessible without authentication. An attacker can access these management interfaces, modify the proxy configuration to add malicious API endpoints, and achieve full SSRF with data exfiltration.

## Vulnerable Code

### 1. CWE-306: Missing auth on management interfaces (CVSS 9.8)

**`nya/server/auth.py:165-210`** ??When `api_key` is empty/unset (the default), all requests pass through authentication:

```python
configured_key = self.auth.get_api_key()
if configured_key is None or (
    isinstance(configured_key, (str, list)) and not configured_key
):
    return await call_next(request)  # <-- auth bypassed for ALL routes
```

**`nya/config.yaml:5`** ??Default configuration has no API key:

```yaml
server:
  api_key:   # <-- empty/null
```

**Attack flow:**
1. Attacker accesses `/config` without any authentication (browser visit, curl, etc.)
2. Attacker adds a new API endpoint config pointing to their malicious server
3. Attacker sends requests through proxy ??requests routed to attacker's server
4. Or: Attacker modifies existing endpoint to point to internal services
5. Proxy follows redirects to private IPs (no SSRF protection in `nya/core/request.py:49`)

### 2. CWE-918: SSRF via unrestricted redirect following

**`nya/core/request.py:49`** ??httpx client follows redirects to any destination:

```python
client_kwargs = {
    "follow_redirects": True,  # <-- no redirect target validation
    ...
}
```

If any configured API endpoint returns a 3xx redirect to `http://169.254.169.254/` or other private IPs, the proxy follows it, exposing cloud metadata and internal services.

### 3. CWE-942: CORS allow_credentials with wildcard origin

**`nya/config.yaml:17-18`** ??CORS specification violation:

```yaml
allow_origins: ["*"]
allow_credentials: true  # <-- forbidden combination
```

## Fix

### `/config` and `/dashboard` now always require authentication

**`nya/server/auth.py`** ??Management interfaces always require auth; auto-generated key when none configured:

```python
# Management interfaces ALWAYS require auth
if is_dashboard or is_config:
    if key_is_unset:
        admin_key = self.auth.ensure_admin_key()  # auto-generates on startup
        # Check provided key against auto-generated admin key
        ...
```

**`ensure_admin_key()`** ??Generates a cryptographically random 32-byte key on first use and prints it to the console:

```python
def ensure_admin_key(self) -> str:
    ...
    self._auto_generated_key = secrets.token_urlsafe(32)
    logger.warning("SECURITY NOTICE: No API key configured.\n"
                    f"Random admin key: {self._auto_generated_key}")
```

### SSRF protection via redirect validation

**`nya/core/request.py`** ??New `_validate_redirect` hook blocks redirects to private IP ranges:

```python
_PRIVATE_NETWORKS = [
    ipaddress.ip_network("127.0.0.0/8"),
    ipaddress.ip_network("10.0.0.0/8"),
    ipaddress.ip_network("172.16.0.0/12"),
    ipaddress.ip_network("192.168.0.0/16"),
    ipaddress.ip_network("169.254.0.0/16"),
    ...
]

def _validate_redirect(request, response):
    target = response.headers.get("location", "")
    if target and _is_private_url(target):
        raise httpx.TooManyRedirects(f"Redirect to private IP blocked: {target}")
```

### CORS fix

Changed `allow_credentials` to `false` in default config ??browsers reject `*` origins with credentials anyway.

## Impact

- Unauthenticated config modification ??arbitrary proxy configuration ??full SSRF
- Redirect following to private IPs ??cloud metadata / internal service access
- CVSS: 9.8 (CRITICAL) ??AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H