### PR TITLE
ci: smoke-test the wheel in an isolated venv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,49 @@ jobs:
 
       - name: Build and smoke-test the wheel
         run: |
+          # `make build` does not clean dist/, so a stale artifact would make
+          # the dist/*.whl glob ambiguous.
+          rm -rf dist
           make build
-          python -m pip install --force-reinstall --no-deps dist/*.whl
-          nyaproxy --version
-          python -c "from importlib.resources import files; assert (files('nya') / 'config.yaml').is_file(); assert (files('nya') / 'schema.json').is_file()"
+
+          # Install into a throwaway venv rather than over the editable
+          # install used by lint and typecheck. That install owns the
+          # `nyaproxy` script, so testing in place cannot distinguish a
+          # working wheel from a wheel whose console script is missing.
+          # Installing with dependencies also asserts that the declared
+          # runtime requirements are actually sufficient.
+          SMOKE="${RUNNER_TEMP:-/tmp}/smoke-venv"
+          rm -rf "$SMOKE"
+          python -m venv "$SMOKE"
+          "$SMOKE/bin/python" -m pip install --quiet dist/*.whl
+
+          # Check the entry point through metadata first: a wheel missing its
+          # console script otherwise surfaces only as "command not found".
+          "$SMOKE/bin/python" - <<'PY'
+          import importlib.metadata as md
+          scripts = {e.name for e in md.entry_points(group="console_scripts")}
+          assert "nyaproxy" in scripts, f"wheel is missing the nyaproxy console script; found {scripts or 'none'}"
+          PY
+
+          "$SMOKE/bin/nyaproxy" --version
+
+          # Data files are not picked up by imports, so they need asserting
+          # explicitly — including the dashboard assets, which the service
+          # serves at runtime and would 404 on if they were dropped.
+          "$SMOKE/bin/python" - <<'PY'
+          from importlib.resources import files
+          root = files("nya")
+          required = [
+              "config.yaml",
+              "schema.json",
+              "html/index.html",
+              "html/login.html",
+              "html/static/css/styles.css",
+              "html/static/js/dashboard.js",
+          ]
+          missing = [p for p in required if not (root / p).is_file()]
+          assert not missing, f"wheel is missing packaged data files: {missing}"
+          PY
 
   test:
     name: Python ${{ matrix.python-version }}


### PR DESCRIPTION
The smoke test installed the freshly built wheel over the editable install that lint and typecheck ran against. That editable install owns the `nyaproxy` script, so the test could not distinguish a working wheel from one whose console script was missing: either way the script was present until the reinstall, and its absence afterwards surfaced only as a bare "nyaproxy: command not found" with nothing naming the cause.

Install into a throwaway venv instead, which is what a user gets from PyPI, and assert the entry point through importlib.metadata before invoking it so a missing console script reports itself. Installing with dependencies rather than --no-deps also covers the declared runtime requirements, which previously rode on the dev environment and were never actually exercised.

Also:
- rm -rf dist first; `make build` does not clean, so a stale artifact makes the dist/*.whl glob ambiguous.
- Assert the packaged dashboard assets. They are data files, so no import failure would catch their loss, and the service 404s at runtime if they are dropped.

Verified by rebuilding with [project.scripts] removed: the new assertion fails with "wheel is missing the nyaproxy console script" instead of the old opaque shell error.