### PR TITLE
ci: start the image before publishing it

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,6 +92,26 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Build a single-arch image and actually start it before publishing
+      # anything. `docker build` never validates ENTRYPOINT, so an image whose
+      # console script is missing builds, pushes, and scans clean, then dies
+      # at runtime with "exec: nyaproxy: not found". The amd64 layers are
+      # reused from cache by the multi-arch build below, so this is cheap.
+      - name: Build image for smoke test
+        if: steps.semantic-release.outputs.released == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          platforms: linux/amd64
+          tags: nyaproxy:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test the image
+        if: steps.semantic-release.outputs.released == 'true'
+        run: docker run --rm nyaproxy:smoke --version
+
       - name: Build and push Docker image
         if: steps.semantic-release.outputs.released == 'true'
         uses: docker/build-push-action@v5


### PR DESCRIPTION
`docker build` never validates ENTRYPOINT, so an image whose console script is missing builds cleanly, pushes to both registries, takes the :latest tag, and passes the Trivy scan — then dies on `docker run` with "exec: nyaproxy: not found". Nothing in the release path ever ran the container, so that failure could only be discovered by a user pulling it.

Build a single-arch image and start it before the publishing steps. The amd64 layers are reused from the gha cache by the multi-arch build that follows, so the extra build is close to free.

Verified both ways: the image built from this tree prints its version, and an image built with [project.scripts] removed builds successfully but exits 127 at the new step, before anything is pushed.