### PR TITLE
fix: expire concurrency locks so a missed release cannot deadlock an API

### DIFF
--- a/nya/common/logging.py
+++ b/nya/common/logging.py
@@ -54,6 +54,16 @@ _MANAGED_LOGGERS = (
     "nacho",
 )
 
+#: Loggers pinned above their default level. watchfiles reports every raw
+#: filesystem event at INFO ("1 change detected"), and Uvicorn's reloader
+#: watches the working directory — which is where the log file usually lives.
+#: Left at INFO, writing a log line produces an event, which logs a line: a
+#: feedback loop that fills the log and the disk with nothing.
+_QUIET_LOGGERS = {
+    "watchfiles": logging.WARNING,
+    "watchfiles.main": logging.WARNING,
+}
+
 
 class Formatter(logging.Formatter):
     """Shared formatter, optionally colouring the level for a terminal."""
@@ -133,4 +143,4 @@ def _reset_managed_loggers() -> None:
         for handler in std_logger.handlers[:]:
             std_logger.removeHandler(handler)
         std_logger.propagate = True
-        std_logger.setLevel(logging.NOTSET)
+        std_logger.setLevel(_QUIET_LOGGERS.get(name, logging.NOTSET))

--- a/nya/core/control.py
+++ b/nya/core/control.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 from ..common.exceptions import APIKeyNotConfiguredError
 from ..services.lb import LoadBalancer
-from ..services.limit import RateLimiter
+from ..services.limit import DEFAULT_LOCK_TTL_SECONDS, RateLimiter
 from ..services.state import state_key
 
 if TYPE_CHECKING:
@@ -192,11 +192,29 @@ class TrafficManager:
         key_concurrency = self.config.get_api_key_concurrency(api_name)
         # Lock key if per-key concurrency is not allowed
         if not key_concurrency:
-            key_limiter.lock()
+            key_limiter.lock(self._lock_ttl(api_name))
 
         # additional metrics update to support the key selection (least_requests)
         key_lb = self.get_load_balancer(api_name)
         key_lb.update_request_count(key, 1)
+
+    def _lock_ttl(self, api_name: str) -> float:
+        """
+        Ceiling on how long one request may hold a key exclusively.
+
+        Generous on purpose: releasing a key that is still in use would put
+        two requests on one credential, which is the very thing
+        key_concurrency: false exists to prevent. A streamed response can also
+        outlive the request timeout, since that bounds only the upstream call.
+        This is a safety net for a missed release, not a scheduling knob.
+        """
+        try:
+            timeout = float(self.config.get_api_default_timeout(api_name))
+        except Exception:
+            return DEFAULT_LOCK_TTL_SECONDS
+        if timeout <= 0:
+            return DEFAULT_LOCK_TTL_SECONDS
+        return max(timeout * 2, 60.0)
 
     def record_ip_request(self, api_name: str, ip: str) -> None:
         """

--- a/nya/services/limit.py
+++ b/nya/services/limit.py
@@ -2,12 +2,20 @@
 Simple rate limiting with time-based recovery.
 """
 
+import logging
 import re
 import time
 from collections import deque
 from typing import Any, Deque, Dict, Optional, Tuple
 
 from ..common.exceptions import ConfigurationError
+
+logger = logging.getLogger(__name__)
+
+#: Fallback ceiling on a concurrency lock when the caller names no deadline.
+#: A lock is released explicitly when the request finishes; this only bounds
+#: the damage when that release is missed.
+DEFAULT_LOCK_TTL_SECONDS = 300.0
 
 
 class RateLimiter:
@@ -34,7 +42,10 @@ class RateLimiter:
         self.request_timestamps: Deque[float] = deque()
         self.last_accessed = time.time()
 
-        self.locked = False
+        # Deadline for the concurrency lock, or None when unlocked. A lock
+        # that could not expire took a credential out of rotation for the
+        # lifetime of the process whenever a release was missed.
+        self._locked_until: Optional[float] = None
         # Explicit cool-down deadline (block_for), independent of the
         # request-window limit so it also works on unlimited limiters.
         self.blocked_until = 0.0
@@ -125,19 +136,42 @@ class RateLimiter:
         # Remove the most recent timestamp
         self.request_timestamps.pop()
 
-    def lock(self) -> None:
+    @property
+    def locked(self) -> bool:
         """
-        Lock the rate limiter to prevent any further requests.
+        Whether a request currently holds this limiter exclusively.
+
+        The lock expires on its own. Every exit from a request releases it
+        explicitly, so an expiry means a release was missed — a bug, but one
+        that must not cost the credential permanently.
+        """
+        if self._locked_until is None:
+            return False
+        if time.time() >= self._locked_until:
+            self._locked_until = None
+            logger.warning(
+                "Concurrency lock on %r expired without being released; "
+                "returning the credential to rotation",
+                self,
+            )
+            return False
+        return True
+
+    def lock(self, ttl: Optional[float] = None) -> None:
+        """
+        Take the limiter exclusively for at most ``ttl`` seconds.
         """
         self.touch()
-        self.locked = True
+        if ttl is None or ttl <= 0:
+            ttl = DEFAULT_LOCK_TTL_SECONDS
+        self._locked_until = time.time() + ttl
 
     def unlock(self) -> None:
         """
         Unlock the rate limiter to allow requests again.
         """
         self.touch()
-        self.locked = False
+        self._locked_until = None
 
     def block_for(self, duration: float) -> None:
         """

--- a/tests/unit/test_core_control.py
+++ b/tests/unit/test_core_control.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from nya.common.exceptions import APIKeyNotConfiguredError
@@ -32,3 +34,24 @@ def test_traffic_manager_select_any_key_requires_configured_keys():
 
     with pytest.raises(APIKeyNotConfiguredError):
         TrafficManager(config).select_any_key("mock")
+
+
+def test_all_keys_locked_recovers_instead_of_deadlocking():
+    """
+    Reproduces the production deadlock: with key_concurrency disabled, every
+    key locked made time_to_key_ready fall through to its `inf` branch and
+    return a constant 1.0s forever, because nothing expired a lock.
+    """
+    config = CoreConfig()
+    config.key_concurrency = False
+    control = TrafficManager(config)
+
+    for key in config.keys:
+        control.get_key_limiter("mock", key).lock(ttl=0.05)
+
+    # The signature operators saw: a wait that never changes and never clears.
+    assert control.time_to_key_ready("mock") == 1.0
+
+    time.sleep(0.06)
+
+    assert control.time_to_key_ready("mock") == 0

--- a/tests/unit/test_limit.py
+++ b/tests/unit/test_limit.py
@@ -11,7 +11,7 @@ import time
 import pytest
 
 from nya.common.exceptions import ConfigurationError
-from nya.services.limit import RateLimiter
+from nya.services.limit import DEFAULT_LOCK_TTL_SECONDS, RateLimiter
 
 # --------------------------------------------------------------------------
 # Rate-limit string parsing
@@ -167,3 +167,44 @@ def test_time_until_reset_zero_when_not_limited():
 
 def test_repr_includes_rate_limit():
     assert "10/m" in repr(RateLimiter("10/m"))
+
+
+def test_lock_expires_so_a_missed_release_cannot_strand_a_key():
+    """
+    Every exit from a request releases the lock explicitly. An expiry means
+    that was missed — a bug, but one that must not cost the credential for
+    the lifetime of the process.
+    """
+    limiter = RateLimiter("0")
+    limiter.lock(ttl=0.05)
+    assert limiter.locked
+
+    time.sleep(0.06)
+
+    assert limiter.locked is False
+    assert limiter.is_limited() is False
+
+
+def test_lock_holds_until_its_deadline():
+    limiter = RateLimiter("0")
+    limiter.lock(ttl=30)
+
+    assert limiter.locked
+    assert limiter.is_limited()
+
+
+def test_explicit_unlock_still_releases_immediately():
+    limiter = RateLimiter("0")
+    limiter.lock(ttl=300)
+    limiter.unlock()
+
+    assert limiter.locked is False
+
+
+def test_lock_without_a_ttl_still_expires():
+    """No caller should be able to create a lock that lives forever."""
+    limiter = RateLimiter("0")
+    limiter.lock()
+
+    assert limiter._locked_until is not None
+    assert limiter._locked_until <= time.time() + DEFAULT_LOCK_TTL_SECONDS + 1


### PR DESCRIPTION
With key_concurrency: false a key is locked for the duration of a request, and nothing ever expired that lock. Any path that failed to release one took the credential out of rotation for the lifetime of the process; once every key had leaked, the API stopped serving entirely and stayed that way.

The reported symptom was a queue stuck for 30 minutes logging a wait that never changed:

  DEBUG | nya.core.queue - Resource Unavailable for novelai endpoint - wait time: 0.50s

That constant is diagnostic. time_to_key_ready treats a locked key as inf, and falls through to a hardcoded `return 1.0` when every key is inf, which the queue halves to 0.50s. A rate-limit wait would count down; only an all-locked pool produces a fixed value forever.

Make the lock a deadline rather than a flag. `locked` becomes a property that expires on its own, so every existing reader — is_limited, _key_is_unavailable, time_to_key_ready — picks up the recovery with no change. The ceiling is twice the API's request timeout, floored at 60s: generous on purpose, because releasing a key still in use would put two requests on one credential, which is the thing key_concurrency: false exists to prevent, and a streamed response can outlive the request timeout since that bounds only the upstream call. An expiry logs a warning: it means a release was missed, which is a bug worth seeing rather than silently absorbing.

Also stop watchfiles logging every filesystem event at INFO. Uvicorn's reloader watches the working directory, which is where log_file usually lives, so writing a log line produced an event that logged a line — a feedback loop visible in the same report as "1 change detected" every 350ms. That was a regression from routing the standard library through the shared handler, which put those records into the log file for the first time.

Verified by mutation: with the expiry removed, both new tests fail with exactly the production signature — time_to_key_ready pinned at 1.0.